### PR TITLE
Allows sorting columns

### DIFF
--- a/lib/active_admin_resource/column_patch.rb
+++ b/lib/active_admin_resource/column_patch.rb
@@ -1,0 +1,11 @@
+module ColumnExtensions
+  def sortable?
+    if @options.has_key?(:sortable)
+      !!@options[:sortable]
+    elsif @resource_class
+      @resource_class.column_names.map(&:name).include?(sort_column_name)
+    else
+      @title.present?
+    end
+  end
+end

--- a/lib/active_admin_resource/railtie.rb
+++ b/lib/active_admin_resource/railtie.rb
@@ -1,13 +1,15 @@
 require 'active_admin_resource/formtastic_addons_patch'
 require 'active_admin_resource/collection_patch'
 require 'active_admin_resource/connection_patch'
+require 'active_admin_resource/column_patch'
 
-module ActiveAdminResource 
+module ActiveAdminResource
   class Railtie < Rails::Railtie
     initializer "railtie.configure_rails_initialization" do
       ActiveResource::Connection.prepend(ConnectionExtensions)
       ActiveAdmin::Helpers::Collection.prepend(CollectionExtensions)
       ActiveAdmin::Filters::FormtasticAddons.prepend(FormtasticAddonsExtensions)
+      ActiveAdmin::Views::TableFor::Column.prepend(ColumnExtensions)
     end
   end
 end


### PR DESCRIPTION
This PR enables columns of the admin view to sort the data, assuming that the corresponding API responds to the "order" param