### PR TITLE
Base Class Improvements & Resource API mock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/active_admin_resource.gemspec
+++ b/active_admin_resource.gemspec
@@ -13,4 +13,11 @@ Gem::Specification.new do |s|
   s.add_dependency "activeadmin"
   s.add_dependency "activeresource"
   s.add_dependency "authograph"
+  s.add_development_dependency 'enumerize', '~> 2.2'
+  s.add_development_dependency 'money-rails', '~> 1.5'
+  s.add_development_dependency 'monetize', '~> 1.3.0'
+  s.add_development_dependency 'money', '~> 6.6'
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'pry'
+  s.add_development_dependency 'formtastic'
 end

--- a/lib/active_admin_resource.rb
+++ b/lib/active_admin_resource.rb
@@ -1,3 +1,5 @@
 require 'active_admin_resource/base'
+require 'active_admin_resource/associations'
+require 'active_admin_resource/gem_adaptors'
 require 'active_admin_resource/agent_data_base'
 require 'active_admin_resource/railtie'

--- a/lib/active_admin_resource/associations.rb
+++ b/lib/active_admin_resource/associations.rb
@@ -1,0 +1,69 @@
+require 'active_resource'
+
+module ActiveAdminResource
+  module Associations
+    def has_many(plural_model_name, options = {})
+      klass = Object.const_get plural_model_name.to_s.singularize.classify
+      # Getter
+      define_method plural_model_name do
+        var = instance_variable_get("@#{plural_model_name}")
+        if !var.nil?
+          var
+        else
+          collection = if options[:as] # polymorphic
+                         foreign_key = "#{options[:as]}_id"
+                         foreign_type = "#{options[:as]}_type"
+                         klass.where(foreign_type => model_name.name, foreign_key => id)
+                       else
+                         foreign_key = "#{model_name.name.downcase}_id"
+                         klass.where(foreign_key => id)
+                       end
+          instance_variable_set("@#{plural_model_name}", collection)
+        end
+      end
+      # Setter
+      define_method "#{plural_model_name}=" do |value|
+        instance_variable_set("@#{plural_model_name}", value)
+      end
+    end
+
+    def has_one(model_name)
+      klass = Object.const_get model_name.to_s.classify
+      # Getter
+      define_method model_name do
+        var = instance_variable_get("@#{model_name}")
+        if !var.nil?
+          var
+        else
+          foreign_key = "#{model_name.name.downcase}_id"
+          instance_variable_set("@#{model_name}", klass.where(foreign_key => id).first)
+        end
+      end
+      # Setter
+      define_method "#{model_name}=" do |value|
+        instance_variable_set("@#{model_name}", value)
+      end
+    end
+
+    Enumerable.send(:define_method, 'and_preload') do |model_to_load|
+      model_to_load = model_to_load.to_s.singularize
+      klass_to_load = Object.const_get model_to_load.classify
+      foreign_ids = map { |collection_item| collection_item.send("#{model_to_load}_id") }.uniq
+      preloaded_items = if klass_to_load < ApplicationResource
+                          # Class to load must support where(id: [])
+                          klass_to_load.where(id: foreign_ids, per: foreign_ids.count)
+                        elsif klass_to_load < ApplicationRecord
+                          klass_to_load.where(id: foreign_ids)
+                        else
+                          raise "#{klass_to_load} is not from a supported preload type"
+                        end
+      each do |collection_item|
+        corresponding_preloaded = preloaded_items.find do |pit|
+          pit.id == collection_item.send("#{model_to_load}_id")
+        end
+        collection_item.send("#{model_to_load}=", corresponding_preloaded)
+      end
+      self
+    end
+  end
+end

--- a/lib/active_admin_resource/base.rb
+++ b/lib/active_admin_resource/base.rb
@@ -5,8 +5,9 @@ require 'active_admin_resource/gem_adaptors'
 module ActiveAdminResource
   class Base < ActiveResource::Base
     extend ActiveAdminResource::Associations
+    extend Enumerize if defined? Enumerize
     extend ActiveAdminResource::GemAdaptors::EnumerizeAdaptor
-    extend ActiveAdminResource::GemAdaptors::RailsMoneyAdaptor
+    extend ActiveAdminResource::GemAdaptors::MoneyAdaptor
 
     class JsonFormatter
       include ActiveResource::Formats::JsonFormat

--- a/lib/active_admin_resource/gem_adaptors.rb
+++ b/lib/active_admin_resource/gem_adaptors.rb
@@ -1,0 +1,47 @@
+require 'active_resource'
+
+module ActiveAdminResource
+  module GemAdaptors
+    module EnumerizeAdaptor
+      # Enumerize support
+      # Model anyway must declare "extend Enumerize", just like an ActiveRecord model would
+      def enumerize(name, options = {})
+        # Getter
+        define_method name do
+          enumerize_attr = self.class.send(name)
+          Enumerize::Value.new(enumerize_attr, attributes[name.to_sym])
+        end
+        # Setter
+        define_method "#{name}=" do |value|
+          enumerize_attr = self.class.send(name)
+          unless value.to_s.in? enumerize_attr.values
+            raise ArgumentError.new "Invalid value '#{value}' for #{name} enumerized attribute"
+          end
+          attributes[name.to_sym] = value
+        end
+        super
+      end
+    end
+
+    module RailsMoneyAdaptor
+      def monetize(*fields)
+        options = fields.extract_options!
+        fields.each { |field| monetize_field(field, options) }
+      end
+
+      def monetize_field(field, _options = {})
+        # Getter
+        define_method field do
+          amount, currency = attributes[field.to_sym]
+          Money.from_amount(amount.to_f, currency) if amount
+        end
+        # Setter
+        define_method "#{field}=" do |new_amount|
+          amount = new_amount.amount
+          currency = new_amount.currency
+          attributes[:amount] = [amount, currency].map(&:to_s)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_admin_resource/railties/resource_api_mock/mock_store.rb
+++ b/lib/active_admin_resource/railties/resource_api_mock/mock_store.rb
@@ -1,0 +1,56 @@
+module ActiveAdminResource
+  class MockStore
+    @@store_hash = Hash.new([])
+
+    def self.select(model, query_params)
+      query_params.stringify_keys!
+      query_params.dup.each do |k, v|
+        if query_params["#{k}_id"].nil? && v.respond_to?(:id)
+          query_params["#{k}_id"] = v.id
+          query_params.delete(k)
+        end
+      end
+      store_for_model(model).select do |obj|
+        obj.attributes.slice(*query_params.keys) == query_params
+      end
+    end
+
+    def self.insert(object)
+      model = object_to_model(object)
+      object.id ||= next_id(model)
+      @@store_hash[model] += [object]
+    end
+
+    def self.update(object)
+      stored_object = store_for_object(object).find { |i| i.id == object.id }
+      raise "Object Not Found: #{object.class} ##{object.id}" unless stored_object
+      store_for_object(object).delete(stored_object)
+      insert(object)
+    end
+
+    def self.delete(object)
+      store_for_object(object).delete(object) ||
+        raise("Object Not Found: #{object.class} ##{object.id}")
+    end
+
+    def self.drop
+      @@store_hash = Hash.new([])
+    end
+
+    def self.object_to_model(object)
+      object.class.name.downcase.to_sym
+    end
+
+    def self.store_for_object(object)
+      store_for_model object_to_model(object)
+    end
+
+    def self.store_for_model(model)
+      @@store_hash[model]
+    end
+
+    def self.next_id(model)
+      (store_for_model(model).map(&:id).max || 0) + 1
+    end
+  end
+end

--- a/lib/active_admin_resource/railties/resource_api_mock/resource_api_mock.rb
+++ b/lib/active_admin_resource/railties/resource_api_mock/resource_api_mock.rb
@@ -1,0 +1,42 @@
+require 'active_resource'
+require 'uri'
+
+module ActiveAdminResource
+  module ResourceApiMock
+    def  self.included(klass)
+      klass.extend ClassMethods
+      klass.site = URI.parse('resource.api.mocked')
+    end
+
+    def site
+      URI.parse('resource.api.mocked')
+    end
+
+    def create
+      @persisted = true
+      MockStore.insert(self)
+    end
+
+    def update
+      MockStore.update(self)
+    end
+
+    def destroy
+      MockStore.delete(self)
+    end
+
+    module ClassMethods
+      def find_every(options)
+        options = options[:params] if options.has_key? :params
+        model = model_name.singular.to_sym
+        MockStore.select(model, options)
+      end
+
+      def find_single(id, options)
+        options = options[:params] if options.has_key? :params
+        model = model_name.singular.to_sym
+        MockStore.select(model, options.merge(id: id.to_i)).first
+      end
+    end
+  end
+end

--- a/lib/active_admin_resource/railties/rspec.rb
+++ b/lib/active_admin_resource/railties/rspec.rb
@@ -1,0 +1,11 @@
+require 'active_admin_resource/railties/resource_api_mock/resource_api_mock'
+require 'active_admin_resource/railties/resource_api_mock/mock_store'
+class ActiveAdminResource::Base
+  include ActiveAdminResource::ResourceApiMock
+end
+
+RSpec.configure do |config|
+  config.before(:example) do |_example|
+    ActiveAdminResource::MockStore.drop
+  end
+end

--- a/spec/lib/gem_adaptors_spec.rb
+++ b/spec/lib/gem_adaptors_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+require 'active_admin_resource/railties/rspec' # Use Resource API Mock
+require 'money'
+require 'money-rails'
+require 'formtastic'
+require 'action_view'
+require 'enumerize'
+
+describe ActiveAdminResource::GemAdaptors do
+
+  class Elephant < ActiveAdminResource::Base
+    enumerize :continent_of_origin, in: [:africa, :asia], default: :asia
+    monetize :cost
+
+    schema do
+      attribute 'id', :integer
+      attribute 'name', :string
+      attribute 'cost', :float # money attribute
+      attribute 'continent_of_origin', :string # enumerize attribute
+    end
+  end
+
+  let(:elephant) { Elephant.create(cost: [455_000.5, 'USD'], continent_of_origin: 'africa') }
+  let(:homeless_elephant) { Elephant.create(name: 'Bill') }
+
+  describe 'Enumerize Adaptor' do
+    describe 'getter' do
+      context 'with a record with persisted continent' do
+        it 'gets correct enumerize value' do
+          expect(elephant.continent_of_origin).to eq('africa')
+          expect(elephant.attributes[:continent_of_origin]).to eq('africa')
+          expect(elephant.continent_of_origin.africa?).to be_truthy
+          expect(elephant.continent_of_origin.class).to eq(Enumerize::Value)
+        end
+      end
+      context 'with a record without continent' do
+        it 'gets default enumerize value' do
+          expect(homeless_elephant.continent_of_origin).to eq('asia')
+          expect(homeless_elephant.attributes[:continent_of_origin]).to eq('asia')
+          expect(homeless_elephant.continent_of_origin.asia?).to be_truthy
+          expect(homeless_elephant.continent_of_origin.class).to eq(Enumerize::Value)
+        end
+      end
+    end
+
+    describe 'setter' do
+      before do
+        homeless_elephant.continent_of_origin = :africa
+      end
+      it 'sets correct enumerize value' do
+        expect(homeless_elephant.continent_of_origin).to eq('africa')
+        expect(homeless_elephant.attributes[:continent_of_origin]).to eq(:africa)
+        expect(elephant.continent_of_origin.africa?).to be_truthy
+      end
+    end
+  end
+
+  describe 'Money Adaptor' do
+
+    describe 'getter' do
+      it 'gets correct money value' do
+        expect(elephant.cost).to eq(Money.from_amount(455_000.5, 'USD'))
+      end
+    end
+
+    describe 'setter' do
+      context 'used with Money object' do
+        it 'sets correct money value' do
+          expect { homeless_elephant.cost = Money.from_amount(150_000, 'USD') }
+            .to change { homeless_elephant.cost }
+            .from(nil).to(Money.from_amount(150_000, 'USD'))
+        end
+      end
+
+      context 'used with numeric value' do
+        it 'sets money value with default currency' do
+          expect { homeless_elephant.cost = 179_800 }
+            .to change { homeless_elephant.cost }
+            .from(nil).to(Money.from_amount(179_800, 'USD'))
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/resource_api_mock_spec.rb
+++ b/spec/lib/resource_api_mock_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'active_admin_resource/railties/rspec' # Use Resource API Mock
+
+describe ActiveAdminResource::ResourceApiMock do
+  class Zoo
+    attr_accessor :id
+    def initialize(id)
+      self.id = id
+    end
+  end
+
+  class Giraffe < ActiveAdminResource::Base
+    belongs_to :zoo
+
+    schema do
+      attribute 'id', :integer
+      attribute 'name', :string
+      attribute 'zoo_id', :integer
+      attribute 'height', :float
+      attribute 'color', :string
+      attribute 'created_at', :datetime
+    end
+  end
+
+  let(:super_zoo) { Zoo.new(1) }
+  let!(:tall_jimmy) do
+    Giraffe.create(name: 'Jimmy', zoo_id: super_zoo.id, height: 4.9, color: 'brown')
+  end
+  let!(:small_george) do
+    Giraffe.create(id: 57, name: 'George', zoo_id: super_zoo.id, height: 3.3, color: 'beige')
+  end
+
+  describe 'unfiltered query via #all' do
+    it 'finds the created records' do
+      expect(Giraffe.all).to eq([tall_jimmy, small_george])
+    end
+  end
+
+  describe 'filtered query via #where' do
+    it 'gets the corresponding records' do
+      expect(Giraffe.where(color: 'brown')).to eq([tall_jimmy])
+      expect(Giraffe.where(zoo: super_zoo)).to eq([tall_jimmy, small_george])
+    end
+  end
+
+  describe 'get single record via #find(<id>)' do
+    it 'gets the corresponding record' do
+      expect(Giraffe.find(57)).to eq(small_george)
+    end
+  end
+
+  describe '#destroy' do
+    before { tall_jimmy.destroy }
+    it "doesn't find the record anymore" do
+      expect(Giraffe.all).to eq([small_george])
+    end
+  end
+
+  describe 'update via #save' do
+    before do
+      small_george.color = 'black'
+      small_george.save
+    end
+    it 'updates record on store' do
+      expect(small_george.reload.color).to eq('black')
+      expect(Giraffe.where(color: 'black')).to eq([small_george])
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+require 'rails'
+require 'active_admin_resource'
+require 'pry'
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
- Add **scopes**  support
- Implement association methods (`has_one`, `has_many`) that work both with ActiveResource as with ActiveRecord collections
- Adds `and_preload(model)` method to perform 1 query instead of N when loading a referenced model
- Add `GemAdaptor` where to add code to support specific gems.  By now **Enumerize** and **RailsMoney** are supported.
- Retrieve url and agent id/password from `RESOURCES_API_XXX` vars by default
- Adds resource API mocking feature for testing models without the need of an API backend